### PR TITLE
use AsyncRead+AsyncWrite instead of Serial

### DIFF
--- a/src/client/rtu.rs
+++ b/src/client/rtu.rs
@@ -5,20 +5,26 @@ use crate::service;
 use futures::Future;
 use std::io::Error;
 use tokio_core::reactor::Handle;
-use tokio_serial::Serial;
+use tokio_io::{AsyncRead, AsyncWrite};
 
 /// Connect to no particular Modbus slave device for sending
 /// broadcast messages.
-pub fn connect(handle: &Handle, serial: Serial) -> impl Future<Item = Context, Error = Error> {
+pub fn connect<T>(handle: &Handle, serial: T) -> impl Future<Item = Context, Error = Error>
+where
+    T: AsyncRead + AsyncWrite + 'static,
+{
     connect_slave(handle, serial, Slave::broadcast())
 }
 
 /// Connect to any kind of Modbus slave device.
-pub fn connect_slave(
+pub fn connect_slave<T>(
     handle: &Handle,
-    serial: Serial,
+    serial: T,
     slave: Slave,
-) -> impl Future<Item = Context, Error = Error> {
+) -> impl Future<Item = Context, Error = Error>
+where
+    T: AsyncRead + AsyncWrite + 'static,
+{
     service::rtu::connect_slave(handle, serial, slave).map(|client| Context {
         client: Box::new(client),
     })

--- a/src/service/rtu.rs
+++ b/src/service/rtu.rs
@@ -6,16 +6,19 @@ use crate::slave::*;
 use futures::{future, Future};
 use std::io::{Error, ErrorKind};
 use tokio_core::reactor::Handle;
+use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_proto::pipeline::ClientService;
 use tokio_proto::BindClient;
-use tokio_serial::Serial;
 use tokio_service::Service;
 
-pub(crate) fn connect_slave(
+pub(crate) fn connect_slave<T>(
     handle: &Handle,
-    serial: Serial,
+    serial: T,
     slave: Slave,
-) -> impl Future<Item = Context, Error = Error> {
+) -> impl Future<Item = Context<T>, Error = Error>
+where
+    T: AsyncRead + AsyncWrite + 'static,
+{
     let proto = Proto;
     let service = proto.bind_client(handle, serial);
     let slave_id = slave.into();
@@ -23,16 +26,16 @@ pub(crate) fn connect_slave(
 }
 
 /// Modbus RTU client
-pub(crate) struct Context {
-    service: ClientService<Serial, Proto>,
+pub(crate) struct Context<T: AsyncRead + AsyncWrite + 'static> {
+    service: ClientService<T, Proto>,
     slave_id: SlaveId,
 }
 
-impl Context {
+impl<T: AsyncRead + AsyncWrite + 'static> Context<T> {
     /// Establish a serial connection with a Modbus server.
     pub fn bind(
         handle: &Handle,
-        serial: Serial,
+        serial: T,
         slave_id: SlaveId,
     ) -> impl Future<Item = Self, Error = Error> {
         let proto = Proto;
@@ -75,13 +78,13 @@ fn verify_response_header(req_hdr: Header, rsp_hdr: Header) -> Result<(), Error>
     Ok(())
 }
 
-impl SlaveContext for Context {
+impl<T: AsyncRead + AsyncWrite + 'static> SlaveContext for Context<T> {
     fn set_slave(&mut self, slave: Slave) {
         self.slave_id = slave.into();
     }
 }
 
-impl Client for Context {
+impl<T: AsyncRead + AsyncWrite + 'static> Client for Context<T> {
     fn call(&self, req: Request) -> Box<dyn Future<Item = Response, Error = Error>> {
         Box::new(self.call(req))
     }


### PR DESCRIPTION
I've been having some trouble with how this crate and its dependencies are designed and interact: mio-serial disables timeouts, tokio-proto's pipeline mode depends on receiving a response (Ok or Err) for each request, and tokio-modbus's rtu mode takes ownership of the serial port. 

My Modbus slave does not always respond to requests, so I need to be able to reset and try again, but there doesn't seem to be any way to tell tokio-proto to give up nor a way to regain ownership of the serial port to reinitialize tokio-modbus.

tokio-modbus doesn't seem to actually use tokio-serial at all except for the `connect` methods in the `sync` module. Replacing `Serial` with `AsyncRead + AsyncWrite + 'static` everywhere else allows for usage of RTU Modbus over other transports (maybe a serial port exposed over TCP?) or in cases like mine where `Serial` just doesn't work on its own.